### PR TITLE
处理阿里druid超过空闲等待时间,断开连接问题

### DIFF
--- a/src/main/java/com/chatviewer/blog/BlogApplication.java
+++ b/src/main/java/com/chatviewer/blog/BlogApplication.java
@@ -17,6 +17,11 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @SpringBootApplication
 public class BlogApplication {
 
+    static {
+        System.setProperty("druid.mysql.usePingMethod","false");
+    }
+
+
     public static void main(String[] args) {
         SpringApplication.run(BlogApplication.class, args);
     }


### PR DESCRIPTION

阿里他们给数据库设置的数据库空闲等待时间是60秒，mysql数据库到了空闲等待时间将关闭空闲的连接，以提升数据库服务器的处理能力。MySQL的默认空闲等待时间是8小时，就是「wait_timeout」的配置值。如果数据库主动关闭了空闲的连接，而连接池并不知道，还在使用这个连接，就会产生异常。
解决方法：
一：更新最新的版本
二：运行参数设置 -Ddruid.mysql.usePingMethod=false